### PR TITLE
Add host and port information to telemetry

### DIFF
--- a/lib/snap.ex
+++ b/lib/snap.ex
@@ -87,6 +87,8 @@ defmodule Snap do
 
   * `method` - the HTTP method used
   * `path` - the path requested
+  * `port` - the port requested
+  * `host` - the host requested
   * `headers` - a list of the headers sent
   * `body` - the body sent
   * `result` - the result returned to the user

--- a/lib/snap/request.ex
+++ b/lib/snap/request.ex
@@ -39,7 +39,9 @@ defmodule Snap.Request do
         total_time: total_time
       }
 
-      metadata = telemetry_metadata(method, path, headers, body, result)
+      uri = URI.parse(url)
+
+      metadata = telemetry_metadata(method, uri, headers, body, result)
 
       :telemetry.execute(event, measurements, metadata)
 
@@ -72,8 +74,8 @@ defmodule Snap.Request do
     end)
   end
 
-  defp telemetry_metadata(method, path, _headers, body, result) do
-    %{method: method, path: path, body: body, result: result}
+  defp telemetry_metadata(method, uri, _headers, body, result) do
+    %{method: method, host: uri.host, port: uri.port, path: uri.path, body: body, result: result}
   end
 
   defp encode_body(body) when is_map(body) do

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -6,7 +6,15 @@ defmodule Snap.TelemetryTest do
   test "telemetry is fired with a request" do
     log = fn event_name, measurements, metadata ->
       assert event_name == [:snap, :snap, :request]
-      assert %{result: {:ok, _}, method: "GET", path: "/_cluster/health", body: nil} = metadata
+
+      assert %{
+               result: {:ok, _},
+               method: "GET",
+               path: "/_cluster/health",
+               host: "localhost",
+               port: 9200,
+               body: nil
+             } = metadata
 
       assert measurements.total_time ==
                measurements.response_time + measurements.decode_time


### PR DESCRIPTION
So that we can keep track of which hosts requests are made to in our
stats expose host and port as part of the telemetry metadata.